### PR TITLE
Disallow indexing of /wish_lists in robots.txt

### DIFF
--- a/app/views/workarea/storefront/pages/_wish_lists_robots.text.erb
+++ b/app/views/workarea/storefront/pages/_wish_lists_robots.text.erb
@@ -1,0 +1,1 @@
+Disallow: /wish_lists

--- a/config/initializers/append_points.rb
+++ b/config/initializers/append_points.rb
@@ -42,6 +42,11 @@ Workarea.append_partials(
 )
 
 Workarea.append_partials(
+  'storefront.robots_txt',
+  'workarea/storefront/pages/wish_lists_robots'
+)
+
+Workarea.append_partials(
   'admin.user_cards',
   'workarea/admin/users/wish_list_card'
 )


### PR DESCRIPTION
This re-enables the behavior removed from Workarea in
workarea-commerce/workarea#108.

Closes #2