### PR TITLE
Ruby 3.x compatibility: update gemspec and replace deprecated APIs

### DIFF
--- a/app/controllers/workarea/storefront/users/wish_lists_controller.rb
+++ b/app/controllers/workarea/storefront/users/wish_lists_controller.rb
@@ -17,7 +17,7 @@ module Workarea
       end
 
       def update
-        current_wish_list.update_attributes(params.permit(:privacy))
+        current_wish_list.update(params.permit(:privacy))
         flash[:success] =
           t('workarea.storefront.flash_messages.wish_list_updated')
         redirect_to users_wish_list_path

--- a/app/models/workarea/wish_list.rb
+++ b/app/models/workarea/wish_list.rb
@@ -152,7 +152,7 @@ module Workarea
     def update_item_quantity(item_id, quantity)
       item = items.where(id: item_id).first
       return false if item.nil?
-      item.update_attributes(quantity: quantity)
+      item.update(quantity: quantity)
     end
 
     # Mark the items as being purchased

--- a/workarea-wish_lists.gemspec
+++ b/workarea-wish_lists.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.license = 'Business Software License'
 
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = ['>= 2.7', '< 3.5']
 
   s.add_dependency 'workarea', '~> 3.x', '>= 3.5.x'
 end


### PR DESCRIPTION
## Summary

Modernizes the plugin for Ruby 3.2+ compatibility.

### Changes
- Set `required_ruby_version` to `['>= 2.7', '< 3.5']` in gemspec
- Replace `update_attributes` with `update` (deprecated/removed in Rails 6.1+)

### Files Changed
- `workarea-wish_lists.gemspec`
- `app/models/workarea/wish_list.rb`
- `app/controllers/workarea/storefront/users/wish_lists_controller.rb`

### Testing
- Verified no remaining `update_attributes` calls
- Backward compatible with Ruby 2.7+

Client impact: None — backward compatible

Closes workarea-commerce/workarea#677